### PR TITLE
Feature/in the works section

### DIFF
--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -7,7 +7,7 @@ const productSchema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required"),
   price: z.coerce.number().gt(0, "Price must be greater than zero"),
-  status: z.enum(["AVAILABLE", "COMING_SOON", "SOLD", "ARCHIVED"]),
+  status: z.enum(["AVAILABLE", "COMING_SOON", "SOLD", "ARCHIVED", "IN_PROGRESS"]),
   images: z.array(z.string().url()).min(1, "At least one image is required"),
   featured: z.boolean().optional(),
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,19 @@ export default async function Home() {
     take: 4,
   });
 
+  const inTheWorks = await prisma.product.findMany({
+    where: {
+      status: "IN_PROGRESS",
+    },
+    include: {
+      images: true,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    take: 2,
+  });
+
   return (
     <div className="bg-black text-white min-h-screen">
       {/* Hero Section */}
@@ -226,22 +239,10 @@ export default async function Home() {
             ready to wear. Keep an eye out.
           </p>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
-            <ItemCard
-              id="item-5"
-              name="Item 5"
-              description="Structured, raw-edged outer layer made from two upcycled work jackets."
-              slug="item-5"
-              status="COMING_SOON"
-            />
-
-            <ItemCard
-              id="item-6"
-              name="Item 6"
-              description="Draped top formed from deconstructed knitwear and shirt panels."
-              slug="item-6"
-              status="COMING_SOON"
-            />
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-8">
+            {inTheWorks.map((product) => (
+              <ItemCard key={product.id} {...product} />
+            ))}
           </div>
         </div>
       </section>

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -19,7 +19,13 @@ interface ItemCardProps {
   slug: string;
   description?: string | null;
   price?: number;
-  status: "AVAILABLE" | "COMING_SOON" | "SOLD" | "ARCHIVED";
+  status:
+    | "AVAILABLE"
+    | "COMING_SOON"
+    | "SOLD"
+    | "ARCHIVED"
+    | "IN_PROGRESS"
+    | string; // Allow string for flexibility
   images?: ImageType[];
 }
 

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -19,13 +19,7 @@ interface ItemCardProps {
   slug: string;
   description?: string | null;
   price?: number;
-  status:
-    | "AVAILABLE"
-    | "COMING_SOON"
-    | "SOLD"
-    | "ARCHIVED"
-    | "IN_PROGRESS"
-    | string; // Allow string for flexibility
+  status: "AVAILABLE" | "COMING_SOON" | "SOLD" | "ARCHIVED" | "IN_PROGRESS";
   images?: ImageType[];
 }
 

--- a/components/admin/EditProductModal.tsx
+++ b/components/admin/EditProductModal.tsx
@@ -31,7 +31,13 @@ const schema = z.object({
   description: z.string().optional(),
   price: z.coerce.number().gt(0),
   featured: z.boolean().optional(),
-  status: z.enum(["AVAILABLE", "COMING_SOON", "SOLD", "ARCHIVED"]),
+  status: z.enum([
+    "AVAILABLE",
+    "COMING_SOON",
+    "SOLD",
+    "ARCHIVED",
+    "IN_PROGRESS",
+  ]),
   images: z
     .array(z.string().url())
     .min(1, "At least one image is required")
@@ -146,6 +152,7 @@ export default function EditProductModal({
                     <SelectItem value="COMING_SOON">Coming Soon</SelectItem>
                     <SelectItem value="SOLD">Sold</SelectItem>
                     <SelectItem value="ARCHIVED">Archived</SelectItem>
+                    <SelectItem value="IN_PROGRESS">In Progress</SelectItem>
                   </SelectGroup>
                 </SelectContent>
               </Select>

--- a/prisma/migrations/20250611201518_add_in_progress_status/migration.sql
+++ b/prisma/migrations/20250611201518_add_in_progress_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ProductStatus" ADD VALUE 'IN_PROGRESS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ enum ProductStatus {
   SOLD
   COMING_SOON
   ARCHIVED
+  IN_PROGRESS
 }
 
 model Product {


### PR DESCRIPTION
This pull request introduces a new product status, `IN_PROGRESS`, and updates various parts of the codebase to support it. The changes span schema definitions, database migrations, UI components, and API logic to ensure consistent handling of the new status.

### Database and Schema Updates:
* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR19): Added `IN_PROGRESS` to the `ProductStatus` enum.
* [`prisma/migrations/20250611201518_add_in_progress_status/migration.sql`](diffhunk://#diff-33b8d9fd62df778e10073752a8f195ce21556954b54ffc93068b00597ff8c7ffR1-R2): Modified the database schema to include the `IN_PROGRESS` status in the `ProductStatus` enum.

### API Updates:
* `app/api/admin/products/[id]/route.ts`: Updated the `productSchema` to include `IN_PROGRESS` as a valid status. ([app/api/admin/products/[id]/route.tsL10-R10](diffhunk://#diff-684facd78df53701bcafbc95328798d3714df8ef8c39afc6f210598bf1b87a6aL10-R10))

### UI Updates:
* [`components/ItemCard.tsx`](diffhunk://#diff-ab44de88cec0f81084270dab1c9889a227e5a1bf349aff92f8d8ff7a1cfac5e2L22-R22): Extended the `ItemCardProps` interface to support the `IN_PROGRESS` status.
* [`components/admin/EditProductModal.tsx`](diffhunk://#diff-4961be0e79442ee3704ab775820b3b5932a9a9266af8503904c928a58fd48677L34-R40): Updated the product editing modal to include `IN_PROGRESS` as a selectable status in the dropdown. [[1]](diffhunk://#diff-4961be0e79442ee3704ab775820b3b5932a9a9266af8503904c928a58fd48677L34-R40) [[2]](diffhunk://#diff-4961be0e79442ee3704ab775820b3b5932a9a9266af8503904c928a58fd48677R155)
* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R24-R36): Modified the homepage logic to fetch and display products with the `IN_PROGRESS` status dynamically, replacing hardcoded items. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R24-R36) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L229-R245)