### PR TITLE
Perf/product page speed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,13 @@ import { prisma } from "@/lib/prisma";
 import Image from "next/image";
 import Link from "next/link";
 
+export const dynamic = "force-static";
+export const revalidate = 60; // revalidates at most every 60s
+export const metadata = {
+  title: "Studio Remade",
+  description: "Nothing New. Everything Remade.",
+};
+
 export default async function Home() {
   // we need to fetch features products
 

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -29,8 +29,6 @@ export default async function ProductPage({
 }) {
   const { slug } = await params;
 
-  console.time("fetchProduct");
-
   const product = await prisma.product.findUnique({
     where: { slug },
     include: {
@@ -38,7 +36,6 @@ export default async function ProductPage({
       images: true,
     },
   });
-  console.timeEnd("fetchProduct");
 
   if (!product) notFound();
 

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -19,12 +19,17 @@ import { statusMap } from "@/lib/statusMap";
 //   AccordionTrigger,
 // } from "@/components/ui/accordion";
 
+export const dynamic = "force-static";
+export const revalidate = 60; // revalidate every 60 seconds
+
 export default async function ProductPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
+
+  console.time("fetchProduct");
 
   const product = await prisma.product.findUnique({
     where: { slug },
@@ -33,6 +38,7 @@ export default async function ProductPage({
       images: true,
     },
   });
+  console.timeEnd("fetchProduct");
 
   if (!product) notFound();
 


### PR DESCRIPTION
This pull request introduces static rendering optimizations and metadata updates to the `app/page.tsx` and `app/products/[slug]/page.tsx` files. The changes aim to improve performance and SEO by enforcing static rendering and adding metadata for the home page.

**Static rendering optimizations:**

* Added `dynamic = "force-static"` and `revalidate = 60` to enforce static rendering and set a revalidation interval of 60 seconds in `app/page.tsx`.
* Added `dynamic = "force-static"` and `revalidate = 60` to enforce static rendering and set a revalidation interval of 60 seconds in `app/products/[slug]/page.tsx`. ([app/products/[slug]/page.tsxR22-R24](diffhunk://#diff-3852fe5473131fa08e70c05be5b18f8df0adc6f6e774f094682e6b511156b2daR22-R24))

**Metadata updates:**

* Added a `metadata` object to `app/page.tsx` with `title` and `description` fields to improve SEO for the home page.