### PR TITLE
Adds configuration to disable body parser and set size limit

### DIFF
--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -97,3 +97,10 @@ export async function DELETE(
     );
   }
 }
+
+export const config = {
+  api: {
+    bodyParser: false, // Disable default body parser to handle form data manually
+    sizeLimit: "50mb", // Set a size limit for the request body
+  },
+};

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -104,3 +104,10 @@ export async function POST(req: NextRequest) {
     );
   }
 }
+
+export const config = {
+  api: {
+    bodyParser: false, // Disable default body parser to handle form data manually
+    sizeLimit: "50mb", // Set a size limit for the request body
+  },
+};


### PR DESCRIPTION
This pull request introduces configuration changes to API routes to improve request handling by disabling the default body parser and setting a size limit for the request body.

Configuration updates for API routes:

* `app/api/admin/products/[id]/route.ts`: Added a `config` object to disable the default body parser and set a request body size limit of 50MB. ([app/api/admin/products/[id]/route.tsR100-R106](diffhunk://#diff-684facd78df53701bcafbc95328798d3714df8ef8c39afc6f210598bf1b87a6aR100-R106))
* [`app/api/products/route.ts`](diffhunk://#diff-a2fd91299cc469f1146a3a5e426d802a20e73cb0e9820d140a9c4c22bf25169fR107-R113): Added a similar `config` object to disable the default body parser and set a request body size limit of 50MB.Implements a custom configuration for the API routes to disable the default body parser, allowing for manual handling of form data.

Sets a size limit of 50mb for the request body to enhance data handling capabilities and prevent excessive load.